### PR TITLE
feat(types): make opts optional in print

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -19,8 +19,8 @@ export function parse(source: string, opts: ParseOptions): Program {
 }
 
 // TODO(littledivy): Typings for `program`
-export function print(program: any, opts: Config): { code: string } {
-  return printSync(program, opts);
+export function print(program: any, opts?: Config): { code: string } {
+  return printSync(program, opts || {});
 }
 
 export function transform(


### PR DESCRIPTION
Currently if you use `{}` for `opts` in `print` it is completely valid, so it makes sense to make it optional.