### PR TITLE
Fixes spelling issue in the interface, and type

### DIFF
--- a/types/options.ts
+++ b/types/options.ts
@@ -1322,15 +1322,15 @@ export interface NamedImportSpecifier extends Node, HasSpan {
 }
 
 export type ExportSpecifier =
-  | ExportNamespaceSpecifer
+  | ExportNamespaceSpecifier
   | ExportDefaultSpecifier
   | NamedExportSpecifier;
 
 /**
  * `export * as foo from 'src';`
  */
-export interface ExportNamespaceSpecifer extends Node, HasSpan {
-  type: "ExportNamespaceSpecifer";
+export interface ExportNamespaceSpecifier extends Node, HasSpan {
+  type: "ExportNamespaceSpecifier";
 
   name: Identifier;
 }


### PR DESCRIPTION
This correctly matches the output of the AST tree. Without this typescript will give an issue when comparing type as it will always be "incorrect".