### PR TITLE
feat: export minify & types

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -6,7 +6,7 @@ import type {
 } from "https://esm.sh/@swc/core@1.2.212/types.d.ts";
 import { instantiate } from "./lib/deno_swc.generated.js";
 
-const { parseSync, printSync, transformSync } = await instantiate(decompress);
+const { parseSync, printSync, transformSync, minifySync } = await instantiate(decompress);
 
 export function parse(source: string, opts: ParseOptions): Program {
   return parseSync(source, opts);
@@ -19,3 +19,9 @@ export function print(program: Program, opts?: Config): { code: string } {
 export function transform(source: string, opts: Config): { code: string } {
   return transformSync(source, opts);
 }
+
+export function minify(source: string, opts?: Config): { code: string } {
+  return minifySync(source, opts);
+}
+
+export * from "https://esm.sh/@swc/core@1.2.212/types.d.ts";


### PR DESCRIPTION
I use some of the types for my own use case when creating utility functions. I could import the `types.d.ts` from `esm.sh`, but that means that the version of swc's types would be desynced if `deno_swc` updates. 

Also, I'm not sure why `minifySync` was excluded - if it was removed for a reason, I'll drop the exporting of it from this PR.